### PR TITLE
feat: add laravel 13, drop laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4]
-        laravel: ['10.*', '11.*', '12.*']
+        php: [8.4, 8.5]
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: ^9.5
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -55,4 +55,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7",
-        "illuminate/contracts": "^8.37|^9|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9|^3",
-        "orchestra/testbench": "^9.0.0||^8.22.0||^10.0",
-        "pestphp/pest": "^2.34|^3.7",
-        "pestphp/pest-plugin-arch": "^2.7|^3",
-        "pestphp/pest-plugin-laravel": "^2.3|^3.1",
+        "orchestra/testbench": "^9.0.0||^10.0||^11.0",
+        "pestphp/pest": "^2.34|^3.7|^4.0",
+        "pestphp/pest-plugin-arch": "^2.7|^3|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.3|^3.1|^4.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^1.1|^2",
         "phpstan/phpstan-phpunit": "^1.3|^2"


### PR DESCRIPTION
## Description

Adds support for Laravel 13 and drops Laravel 10 support. Updates the `illuminate/contracts` constraint to `^11.0|^12.0|^13.0` and adds the corresponding `orchestra/testbench` and CI matrix entries.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [x] Documentation is up-to-date.